### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,11 @@ Create a test repository and clone it. replace <publickey> with the hex represen
 
 ```bash
 ./bin/gn repo create test
-./bin/gn repo clone  <publickey>:test
+./bin/gn repo clone <publickey>:test
 ```
 
 You can set write permission for your repository with the following command. replace <publickey> with the hex represenation of your public key. If you are using a nip05 capable public key you can use the nip05 identifier instead.
 
 ```bash
-./bin/gn repo permissions test <publickey> WRITE
+./bin/gn repo permission test <publickey> WRITE
 ```


### PR DESCRIPTION
readme.md has instructions to use the command `repo permissions` when it should be `repo permission`.

From main.go:

```go
switch cmd {
	case "repo":
		subcmd := os.Args[2]
		switch subcmd {
		case "create":
			repoCreate(cfg, pool)
		case "clone":
			repoClone(cfg, pool)
		case "permission": // relevant case here
			repoPermission(cfg, pool)
		default:
			log.Fatalf("unknown repo sub command %v", subcmd)
		}
```